### PR TITLE
Use hfr daedalus

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus.data
 Title: DAEDALUS Data
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: c(
     person("Pablo", "Perez-Guzman", , "p.perez-guzman@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5277-5196")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus.data 0.0.2
+
+- Use HFR in daedalus, instead of omega and gamma_H
+
 # daedalus.data 0.0.1
 
 Initial package setup. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # daedalus.data 0.0.2
 
-- Use HFR in daedalus, instead of omega and gamma_H
+- Pass age-specific HFR to process as conditional probability in daedalus.
 
 # daedalus.data 0.0.1
 

--- a/R/infection_data.R
+++ b/R/infection_data.R
@@ -49,6 +49,12 @@
 #'
 #' - `gamma_Ia`: A single numeric value for the recovery rate from asymptomatic
 #' infection.
+#' 
+#' - `gamma_H_recovery`: A single numeric value for the rate of transition 
+#' from hospital admission to recovery.
+#' 
+#' - `gamma_H_death`: A single numeric value for the rate of transition from
+#' hospital admission to death.
 #'
 #' - `hfr`: A numeric vector of length 4 for the age-specific hospital fatality
 #' ratio.

--- a/R/infection_data.R
+++ b/R/infection_data.R
@@ -50,14 +50,11 @@
 #' - `gamma_Ia`: A single numeric value for the recovery rate from asymptomatic
 #' infection.
 #'
-#' - `gamma_H`: A numeric vector of length 4 for the age-specific recovery rate
-#' for individuals who are hospitalised.
+#' - `hfr`: A numeric vector of length 4 for the age-specific hospital fatality
+#' ratio.
 #'
 #' - `eta`: A numeric vector of length `N_AGE_GROUPS` (4) for the age-specific
 #' hospitalisation rate for individuals who are infectious and symptomatic.
-#'
-#' - `omega`: A numeric vector of length `N_AGE_GROUPS` (4) for the age-specific
-#' mortality rate for individuals who are hospitalised.
 #'
 #' - `rho`: A single numeric value for the rate at which infection-derived
 #' immunity wanes, returning individuals in the 'recovered' compartment to the

--- a/R/infection_data.R
+++ b/R/infection_data.R
@@ -50,9 +50,9 @@
 #' - `gamma_Ia`: A single numeric value for the recovery rate from asymptomatic
 #' infection.
 #'
-#' - `gamma_H_recovery`: A single numeric value for the rate of transition 
+#' - `gamma_H_recovery`: A single numeric value for the rate of transition
 #' from hospital admission to recovery.
-#' 
+#'
 #' - `gamma_H_death`: A single numeric value for the rate of transition from
 #' hospital admission to death.
 #'

--- a/R/infection_data.R
+++ b/R/infection_data.R
@@ -49,7 +49,7 @@
 #'
 #' - `gamma_Ia`: A single numeric value for the recovery rate from asymptomatic
 #' infection.
-#' 
+#'
 #' - `gamma_H_recovery`: A single numeric value for the rate of transition 
 #' from hospital admission to recovery.
 #' 

--- a/data-raw/infection_data.R
+++ b/data-raw/infection_data.R
@@ -132,13 +132,13 @@ data_rho <- data_params[code_label == "Ti", ]
 data_rho[, value := 1 / value][, measure := "rho"]
 data_rho <- data_rho[, c("measure", "epidemic", "value")]
 
-## gamma_H: rate of transition from hospital to recovered
+## gamma_H_recovery: rate of transition from hospital to recovered
 data_gamma_H_recovery <- data_params[code_label == "Threc", ]
 data_gamma_H_recovery[, value := 1 / value][, measure := "gamma_H_recovery"]
 data_gamma_H_recovery <- 
   data_gamma_H_recovery[, c("measure", "epidemic", "value")]
 
-## omega: rate of transition from hospital to recovered
+## gamma_H_death: rate of transition from hospital to recovered
 data_gamma_H_death <- data_params[code_label == "Thd", ]
 data_gamma_H_death[, value := 1 / value][, measure := "gamma_H_death"]
 data_gamma_H_death <- data_gamma_H_death[, c("measure", "epidemic", "value")]

--- a/data-raw/infection_data.R
+++ b/data-raw/infection_data.R
@@ -132,6 +132,17 @@ data_rho <- data_params[code_label == "Ti", ]
 data_rho[, value := 1 / value][, measure := "rho"]
 data_rho <- data_rho[, c("measure", "epidemic", "value")]
 
+## gamma_H: rate of transition from hospital to recovered
+data_gamma_H_recovery <- data_params[code_label == "Threc", ]
+data_gamma_H_recovery[, value := 1 / value][, measure := "gamma_H_recovery"]
+data_gamma_H_recovery <- 
+  data_gamma_H_recovery[, c("measure", "epidemic", "value")]
+
+## omega: rate of transition from hospital to recovered
+data_gamma_H_death <- data_params[code_label == "Thd", ]
+data_gamma_H_death[, value := 1 / value][, measure := "gamma_H_death"]
+data_gamma_H_death <- data_gamma_H_death[, c("measure", "epidemic", "value")]
+
 ## combine pathogen data and convert to named list of lists
 infection_data <- rbindlist(list(
   data_r0,
@@ -140,7 +151,9 @@ infection_data <- rbindlist(list(
   data_epsilon,
   data_rho,
   data_gamma_ia,
-  data_gamma_is
+  data_gamma_is,
+  data_gamma_H_recovery,
+  data_gamma_H_death
 ))
 infection_data <- split(infection_data, by = "epidemic") |>
   lapply(function(dt) {

--- a/data-raw/infection_data.R
+++ b/data-raw/infection_data.R
@@ -99,10 +99,10 @@ data_omega_eta <- merge(data_ifr_ihr, data_hosp)
 
 # calculate daily rates
 # eta = (ihr / p_sigma) / Tsh
-# p(death) = ifr / ihr
-# T{hosp} = p(death) * Thd + (1 - p(death)) * Threc
-# omega = p(death) / T{hosp}
-# gamma_H = (1 - p(death)) / T{hosp}
+# hfr = ifr / ihr
+# T{hosp} = hfr * Thd + (1 - hfr) * Threc
+# omega = hfr / T{hosp}
+# gamma_H = (1 - hfr) / T{hosp}
 data_omega_eta[, c("eta", "p_death") := list((ihr / ps) / Tsh, ifr / ihr)]
 data_omega_eta[, t_hosp := p_death * Thd + (1 - p_death) * Threc]
 data_omega_eta[,

--- a/man/epidemic_data.Rd
+++ b/man/epidemic_data.Rd
@@ -28,12 +28,10 @@ symptomatic individuals).
 individuals who are not hospitalised.
 \item \code{gamma_Ia}: A single numeric value for the recovery rate from asymptomatic
 infection.
-\item \code{gamma_H}: A numeric vector of length 4 for the age-specific recovery rate
-for individuals who are hospitalised.
+\item \code{hfr}: A numeric vector of length 4 for the age-specific hospital fatality
+ratio.
 \item \code{eta}: A numeric vector of length \code{N_AGE_GROUPS} (4) for the age-specific
 hospitalisation rate for individuals who are infectious and symptomatic.
-\item \code{omega}: A numeric vector of length \code{N_AGE_GROUPS} (4) for the age-specific
-mortality rate for individuals who are hospitalised.
 \item \code{rho}: A single numeric value for the rate at which infection-derived
 immunity wanes, returning individuals in the 'recovered' compartment to the
 'susceptible' compartment.

--- a/man/epidemic_data.Rd
+++ b/man/epidemic_data.Rd
@@ -28,6 +28,10 @@ symptomatic individuals).
 individuals who are not hospitalised.
 \item \code{gamma_Ia}: A single numeric value for the recovery rate from asymptomatic
 infection.
+\item \code{gamma_H_recovery}: A single numeric value for the rate of transition
+from hospital admission to recovery.
+\item \code{gamma_H_death}: A single numeric value for the rate of transition from
+hospital admission to death.
 \item \code{hfr}: A numeric vector of length 4 for the age-specific hospital fatality
 ratio.
 \item \code{eta}: A numeric vector of length \code{N_AGE_GROUPS} (4) for the age-specific


### PR DESCRIPTION
This PR fixes #4 by removing `omega` and `gamma_H` calculations, replacing it with just `hfr`, which will be processed within `daedalus.cpp`.